### PR TITLE
Adding TPP equations to TimePredSingle and VolIntSingle; moving BCAST from the first argument

### DIFF
--- a/src/impl/seismic/kernels/SurfIntSingle.hpp
+++ b/src/impl/seismic/kernels/SurfIntSingle.hpp
@@ -173,9 +173,9 @@ class edge::seismic::kernels::SurfIntSingle: public edge::seismic::kernels::Surf
                 static_cast<real_base>(1.0), // alpha
                 static_cast<real_base>(1.0), // beta
                 LIBXSMM_GEMM_PREFETCH_NONE );
-
+#ifdef ELTWISE_TPP
       u_unary.add(0, TL_N_MDS_EL * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_UNARY_XOR, LIBXSMM_MELTW_FLAG_UNARY_NONE);
-
+#endif
     }
 
   public:

--- a/src/impl/seismic/kernels/TimePredFused.hpp
+++ b/src/impl/seismic/kernels/TimePredFused.hpp
@@ -329,11 +329,11 @@ class edge::seismic::kernels::TimePredFused: public edge::seismic::kernels::Time
 #ifdef ELTWISE_TPP
       // initialize zero-derivative, reset time integrated dofs
       u_unary.add(0, TL_N_CRS, TL_N_MDS * TL_N_QTS_E /* m, n */, LIBXSMM_MELTW_TYPE_UNARY_IDENTITY, LIBXSMM_MELTW_FLAG_UNARY_NONE);
-      b_binary.add(0, TL_N_CRS, TL_N_MDS * TL_N_QTS_E /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(0, TL_N_CRS, TL_N_MDS * TL_N_QTS_E /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
 
       // anelastic: init zero-derivative, reset tDofs
       u_unary.add(1,  TL_N_CRS * TL_N_MDS * TL_N_QTS_M, TL_N_RMS /* m, n */, TL_N_CRS * TL_N_MDS * TL_N_QTS_M, TL_N_CRS * TL_N_MDS * TL_N_QTS_M * TL_O_TI /*ldi, ldo */, LIBXSMM_MELTW_TYPE_UNARY_IDENTITY, LIBXSMM_MELTW_FLAG_UNARY_NONE);
-      b_binary.add(1, TL_N_CRS, TL_N_MDS * TL_N_QTS_M * TL_N_RMS /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(1, TL_N_CRS, TL_N_MDS * TL_N_QTS_M * TL_N_RMS /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
 
       // zeroing the derivative for elastic
       u_unary.add(2, TL_N_CRS, TL_N_MDS * TL_N_QTS_E /* m, n */, LIBXSMM_MELTW_TYPE_UNARY_XOR, LIBXSMM_MELTW_FLAG_UNARY_NONE);
@@ -348,16 +348,16 @@ class edge::seismic::kernels::TimePredFused: public edge::seismic::kernels::Time
       // addition
       b_binary.add(3, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
       // mult + assign
-      b_binary.add(3, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(3, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
       // accumulation 2
-      b_binary.add(3, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(3, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
       b_binary.add(3, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
 
       // update time integrated dofs
       for( unsigned short l_de = 1; l_de < TL_O_TI; l_de++ ) {
         unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
         b_binary.add(4, TL_N_CRS * l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_CRS * TL_N_MDS, TL_N_CRS * TL_N_MDS, TL_N_CRS * TL_N_MDS /* ldi0, ldi1, ldo */,
-                      LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+                      LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
         b_binary.add(5, TL_N_CRS * l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_CRS * TL_N_MDS, TL_N_CRS * TL_N_MDS, TL_N_CRS * TL_N_MDS /* ldi0, ldi1, ldo */,
                       LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
       }
@@ -480,7 +480,7 @@ class edge::seismic::kernels::TimePredFused: public edge::seismic::kernels::Time
       /* 1. o_derE[0][l_qt][l_md][l_cfr] = i_dofsE[l_qt][l_md][l_cfr] */
       u_unary.execute(0, 0, &i_dofsE[0][0][0], &o_derE[0][0][0][0]);
       /* 2. o_tIntE[l_qt][l_md][l_cfr]   = l_scalar * i_dofsE[l_qt][l_md][l_cfr]*/
-      b_binary.execute(0, 0, &l_scalar, &i_dofsE[0][0][0], &o_tIntE[0][0][0]);
+      b_binary.execute(0, 0, &i_dofsE[0][0][0], &l_scalar, &o_tIntE[0][0][0]);
 #else
       for( unsigned short l_qt = 0; l_qt < TL_N_QTS_E; l_qt++ ) {
         for( unsigned short l_md = 0; l_md < TL_N_MDS; l_md++ ) {
@@ -498,7 +498,7 @@ class edge::seismic::kernels::TimePredFused: public edge::seismic::kernels::Time
         /* 1. o_derA[l_rm][0][l_qt][l_md][l_cr] = i_dofsA[l_rm][l_qt][l_md][l_cr] */
         u_unary.execute(1, 0, &i_dofsA[0][0][0][0], &o_derA[0][0][0][0][0]);
         /* 2. o_tIntA[l_rm][l_qt][l_md][l_cr] = l_scalar * i_dofsA[l_rm][l_qt][l_md][l_cr] */
-        b_binary.execute(1, 0, &l_scalar, &i_dofsA[0][0][0][0], &o_tIntA[0][0][0][0]);
+        b_binary.execute(1, 0, &i_dofsA[0][0][0][0], &l_scalar, &o_tIntA[0][0][0][0]);
 #else
       for( unsigned short l_rm = 0; l_rm < TL_N_RMS; l_rm++ ) {
         for( unsigned short l_qt = 0; l_qt < TL_N_QTS_M; l_qt++ ) {
@@ -595,10 +595,10 @@ class edge::seismic::kernels::TimePredFused: public edge::seismic::kernels::Time
           b_binary.execute(3, 0, &l_scratch[0][0][0], &o_derA[l_rm][l_de-1][0][0][0], &l_scratch2[0][0][0]);
 
           /* 2  o_derA[l_rm][l_de][l_qt][l_md][0] = l_rfs[l_rm] * l_scratch2[l_qt][l_md][l_cr] */
-          b_binary.execute(3, 1, &l_rfs[l_rm], &l_scratch2[0][0][0], &o_derA[l_rm][l_de][0][0][0]);
+          b_binary.execute(3, 1, &l_scratch2[0][0][0], &l_rfs[l_rm], &o_derA[l_rm][l_de][0][0][0]);
 
           /* 3.1 l_scratch2 = l_scalar * o_derA[l_rm][l_de][l_qt][l_md][l_cr] */
-          b_binary.execute(3, 2, &l_scalar, &o_derA[l_rm][l_de][0][0][0], &l_scratch2[0][0][0]);
+          b_binary.execute(3, 2, &o_derA[l_rm][l_de][0][0][0], &l_scalar, &l_scratch2[0][0][0]);
           /* 3.2 o_tIntA[l_rm][l_qt][l_md][l_cr] += l_scratch2[l_qt][l_md][l_cr] */
           b_binary.execute(3, 3, &o_tIntA[l_rm][0][0][0], &l_scratch2[0][0][0], &o_tIntA[l_rm][0][0][0]);
 #else
@@ -620,7 +620,7 @@ class edge::seismic::kernels::TimePredFused: public edge::seismic::kernels::Time
             to the missing support for TERNARY_BCAST flags outside equations) */
 
         /* 1.1 l_scratch3[][][] = l_scalar * o_derE[l_de][l_qt][l_md][l_cr] */
-        b_binary.execute(4, l_de-1, &l_scalar, &o_derE[l_de][0][0][0], &l_scratch3[0][0][0]);
+        b_binary.execute(4, l_de-1, &o_derE[l_de][0][0][0], &l_scalar, &l_scratch3[0][0][0]);
 
         /* 1.2 o_tIntE[l_qt][l_md][l_cr] += l_scratch3 */
         b_binary.execute(5, l_de-1, &o_tIntE[0][0][0], &l_scratch3[0][0][0], &o_tIntE[0][0][0]);

--- a/src/impl/seismic/kernels/TimePredSingle.hpp
+++ b/src/impl/seismic/kernels/TimePredSingle.hpp
@@ -207,8 +207,8 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
         b_binary.add(5, l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_MDS, TL_N_MDS, TL_N_MDS /* ldi0, ldi1, ldo */,
                       LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
       }
-#  ifdef EQUATION_TPP
 
+#  ifdef EQUATION_TPP
       for( unsigned short l_de = 1; l_de < TL_O_TI; l_de++ ) {
         unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
 
@@ -283,7 +283,6 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
         e_eqns00.push_back(func00);
 
         // adding to eqns01 (multiply with relaxation frequency and add, part 2)
-
 
         libxsmm_blasint my_eqn01 = libxsmm_matrix_eqn_create();         /* o_tintA += l_scalar * o_derA */
 
@@ -471,7 +470,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       }
 #endif
 
-#ifdef EQUATION_TPP
+#if defined(ELTWISE_TPP) and defined(EQUATION_TPP)
       libxsmm_matrix_arg arg_array[3];
       libxsmm_matrix_eqn_param eqn_param;
       memset( &eqn_param, 0, sizeof(eqn_param));
@@ -565,7 +564,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
           eqn_param.output.primary = &o_derA[l_rm][l_de][0][0][0];
           e_eqns00[l_de-1](&eqn_param);
 
-          arg_array[0].primary     = &l_scalar;                                      /* [1] */
+          arg_array[0].primary     = &l_scalar;
           arg_array[1].primary     = &o_derA[l_rm][l_de][0][0][0];
           arg_array[2].primary     = &o_tIntA[l_rm][0][0][0];
           eqn_param.output.primary = &o_tIntA[l_rm][0][0][0];

--- a/src/impl/seismic/kernels/TimePredSingle.hpp
+++ b/src/impl/seismic/kernels/TimePredSingle.hpp
@@ -177,11 +177,11 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 #ifdef ELTWISE_TPP
       // initialize zero-derivative, reset time integrated dofs
       u_unary.add(0, TL_N_MDS * TL_N_QTS_E, 1 /* m, n */,  LIBXSMM_MELTW_TYPE_UNARY_IDENTITY, LIBXSMM_MELTW_FLAG_UNARY_NONE);
-      b_binary.add(0, TL_N_MDS * TL_N_QTS_E, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(0, TL_N_MDS * TL_N_QTS_E, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
 
       // anelastic: init zero-derivative, reset tDofs
       u_unary.add(1,  TL_N_MDS * TL_N_QTS_M, TL_N_RMS /* m, n */, TL_N_MDS * TL_N_QTS_M, TL_N_MDS * TL_N_QTS_M * TL_O_TI /*ldi, ldo */, LIBXSMM_MELTW_TYPE_UNARY_IDENTITY, LIBXSMM_MELTW_FLAG_UNARY_NONE);
-      b_binary.add(1, TL_N_MDS * TL_N_QTS_M, TL_N_RMS /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(1, TL_N_MDS * TL_N_QTS_M, TL_N_RMS /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
 
       // zeroing: elastic: reset this derivative
       u_unary.add(2, TL_N_MDS * TL_N_QTS_E, 1 /* m, n */, LIBXSMM_MELTW_TYPE_UNARY_XOR, LIBXSMM_MELTW_FLAG_UNARY_NONE);
@@ -193,9 +193,9 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       // addition
       b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
       // mult + assign
-      b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
       // accumulation 2
-      b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
       b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
 
 
@@ -203,7 +203,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       for( unsigned short l_de = 1; l_de < TL_O_TI; l_de++ ) {
         unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
         b_binary.add(4, l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_MDS, TL_N_MDS, TL_N_MDS /* ldi0, ldi1, ldo */,
-                      LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+                      LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
         b_binary.add(5, l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_MDS, TL_N_MDS, TL_N_MDS /* ldi0, ldi1, ldo */,
                       LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
       }
@@ -273,8 +273,8 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
         eqn_out_arg_shape.ld   = TL_N_MDS;
         eqn_out_arg_shape.type = dtype;
 
-        libxsmm_matrix_eqn_tree_print( my_eqn00 );
-        libxsmm_matrix_eqn_rpn_print ( my_eqn00 );
+        //libxsmm_matrix_eqn_tree_print( my_eqn00 );
+        //libxsmm_matrix_eqn_rpn_print ( my_eqn00 );
         libxsmm_matrix_eqn_function func00 = libxsmm_dispatch_matrix_eqn_v2( my_eqn00, eqn_out_arg_shape );
         if ( func00 == NULL) {
           fprintf( stderr, "JIT for TPP equation func00 (eqn00) failed. Bailing...!\n");
@@ -286,24 +286,24 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
         libxsmm_blasint my_eqn01 = libxsmm_matrix_eqn_create();         /* o_tintA += l_scalar * o_derA */
 
-        ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_0;
+        ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1;
         op_metadata.eqn_idx      = my_eqn01;
         op_metadata.op_arg_pos   = -1;
         libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, dtype_comp, ternary_flags);
 
         arg_metadata.eqn_idx     = my_eqn01;
         arg_metadata.in_arg_pos  = 0;
-        arg_shape.m    = 1;                                             /* l_scalar, [1] */
-        arg_shape.n    = 1;
-        arg_shape.ld   = 1;
+        arg_shape.m    = TL_N_MDS;                                      /* o_derA, [TL_N_MDS][TL_N_QTS_M] */
+        arg_shape.n    = TL_N_QTS_M;
+        arg_shape.ld   = TL_N_MDS;
         arg_shape.type = dtype;
         libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
 
         arg_metadata.eqn_idx     = my_eqn01;
         arg_metadata.in_arg_pos  = 1;
-        arg_shape.m    = TL_N_MDS;                                      /* o_derA, [TL_N_MDS][TL_N_QTS_M] */
-        arg_shape.n    = TL_N_QTS_M;
-        arg_shape.ld   = TL_N_MDS;
+        arg_shape.m    = 1;                                             /* l_scalar, [1] */
+        arg_shape.n    = 1;
+        arg_shape.ld   = 1;
         arg_shape.type = dtype;
         libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
 
@@ -320,8 +320,8 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
         eqn_out_arg_shape.ld   = TL_N_MDS;
         eqn_out_arg_shape.type = dtype;
 
-        libxsmm_matrix_eqn_tree_print( my_eqn01 );
-        libxsmm_matrix_eqn_rpn_print ( my_eqn01 );
+        //libxsmm_matrix_eqn_tree_print( my_eqn01 );
+        //libxsmm_matrix_eqn_rpn_print ( my_eqn01 );
         libxsmm_matrix_eqn_function func01 = libxsmm_dispatch_matrix_eqn_v2( my_eqn01, eqn_out_arg_shape );
         if ( func01 == NULL) {
           fprintf( stderr, "JIT for TPP equation func01 (eqn01) failed. Bailing...!\n");
@@ -333,24 +333,24 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
         libxsmm_blasint my_eqn1 = libxsmm_matrix_eqn_create();          /* o_tintE += l_scalar * o_derE */
 
-        ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_0;
+        ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1;
         op_metadata.eqn_idx      = my_eqn1;
         op_metadata.op_arg_pos   = -1;
         libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, dtype_comp, ternary_flags);
 
         arg_metadata.eqn_idx     = my_eqn1;
         arg_metadata.in_arg_pos  = 0;
-        arg_shape.m    = 1;                                             /* l_scalar, [1]*/
-        arg_shape.n    = 1;
-        arg_shape.ld   = 1;
+        arg_shape.m    = l_nCpMds;                                      /* o_derE[l_de], [l_ncpMds*][TL_N_QTS_E] */
+        arg_shape.n    = TL_N_QTS_E;
+        arg_shape.ld   = TL_N_MDS;
         arg_shape.type = dtype;
         libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
 
         arg_metadata.eqn_idx     = my_eqn1;
         arg_metadata.in_arg_pos  = 1;
-        arg_shape.m    = l_nCpMds;                                      /* o_derE[l_de], [l_ncpMds*][TL_N_QTS_E] */
-        arg_shape.n    = TL_N_QTS_E;
-        arg_shape.ld   = TL_N_MDS;
+        arg_shape.m    = 1;                                             /* l_scalar, [1]*/
+        arg_shape.n    = 1;
+        arg_shape.ld   = 1;
         arg_shape.type = dtype;
         libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
 
@@ -368,8 +368,8 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
         eqn_out_arg_shape.ld   = TL_N_MDS;
         eqn_out_arg_shape.type = dtype;
 
-        libxsmm_matrix_eqn_tree_print( my_eqn1 );
-        libxsmm_matrix_eqn_rpn_print ( my_eqn1 );
+        //libxsmm_matrix_eqn_tree_print( my_eqn1 );
+        //libxsmm_matrix_eqn_rpn_print ( my_eqn1 );
         libxsmm_matrix_eqn_function func1 = libxsmm_dispatch_matrix_eqn_v2( my_eqn1, eqn_out_arg_shape );
         if ( func1 == NULL) {
           fprintf( stderr, "JIT for TPP equation func1 (eqn1) failed. Bailing...!\n");
@@ -441,7 +441,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       /* 1. o_derE[0][l_qt][l_md][0] = i_dofsE[l_qt][l_md][0] */
       u_unary.execute(0, 0, &i_dofsE[0][0][0], &o_derE[0][0][0][0]);
       /* 2. o_tIntE[l_qt][l_md][0]   = l_scalar * i_dofsE[l_qt][l_md][0] */
-      b_binary.execute(0, 0, &l_scalar, &i_dofsE[0][0][0], &o_tIntE[0][0][0]);
+      b_binary.execute(0, 0, &i_dofsE[0][0][0], &l_scalar, &o_tIntE[0][0][0]);
 #else
       for( unsigned short l_qt = 0; l_qt < TL_N_QTS_E; l_qt++ ) {
 #pragma omp simd
@@ -457,7 +457,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       /* 1. o_derA[l_rm][0][l_qt][l_md][0] = i_dofsA[l_rm][l_qt][l_md][0]; */
       u_unary.execute(1, 0, &i_dofsA[0][0][0][0], &o_derA[0][0][0][0][0]);
       /* 2. o_tIntA[l_rm][l_qt][l_md][0] = l_scalar * i_dofsA[l_rm][l_qt][l_md][0] */
-      b_binary.execute(1, 0, &l_scalar, &i_dofsA[0][0][0][0], &o_tIntA[0][0][0][0]);
+      b_binary.execute(1, 0, &i_dofsA[0][0][0][0], &l_scalar, &o_tIntA[0][0][0][0]);
 #else
       for( unsigned short l_rm = 0; l_rm < TL_N_RMS; l_rm++ ) {
         for( unsigned short l_qt = 0; l_qt < TL_N_QTS_M; l_qt++ ) {
@@ -564,8 +564,8 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
           eqn_param.output.primary = &o_derA[l_rm][l_de][0][0][0];
           e_eqns00[l_de-1](&eqn_param);
 
-          arg_array[0].primary     = &l_scalar;
-          arg_array[1].primary     = &o_derA[l_rm][l_de][0][0][0];
+          arg_array[0].primary     = &o_derA[l_rm][l_de][0][0][0];
+          arg_array[1].primary     = &l_scalar;
           arg_array[2].primary     = &o_tIntA[l_rm][0][0][0];
           eqn_param.output.primary = &o_tIntA[l_rm][0][0][0];
           e_eqns01[l_de-1](&eqn_param);
@@ -574,10 +574,10 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
           b_binary.execute(3, 0, &l_scratch[0][0], &o_derA[l_rm][l_de-1][0][0][0], &l_scratch2[0][0]);
 
           /* 2  o_derA[l_rm][l_de][l_qt][l_md][0] = l_rfs[l_rm] * l_scratch2[l_qt][l_md][0] */
-          b_binary.execute(3, 1, &l_rfs[l_rm], &l_scratch2[0][0], &o_derA[l_rm][l_de][0][0][0]);
+          b_binary.execute(3, 1, &l_scratch2[0][0], &l_rfs[l_rm], &o_derA[l_rm][l_de][0][0][0]);
 
           /* 3.1 l_scratch2 = l_scalar * o_derA[l_rm][l_de][l_qt][l_md][0] */
-          b_binary.execute(3, 2, &l_scalar, &o_derA[l_rm][l_de][0][0][0], &l_scratch2[0][0]);
+          b_binary.execute(3, 2, &o_derA[l_rm][l_de][0][0][0], &l_scalar, &l_scratch2[0][0]);
           /* 3.2 o_tIntA[l_rm][l_qt][l_md][0] += l_scratch2[l_qt][l_md][0] */
           b_binary.execute(3, 3, &o_tIntA[l_rm][0][0][0], &l_scratch2[0][0], &o_tIntA[l_rm][0][0][0]);
 #  endif
@@ -596,8 +596,8 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
         // elastic: update time integrated DOFs
 #ifdef ELTWISE_TPP
 #  ifdef EQUATION_TPP
-        arg_array[0].primary     = &l_scalar;                                      /* [1] */
-        arg_array[1].primary     = &o_derE[l_de][0][0][0];                         /* [l_nCpMds, TL_N_QTS_E] */
+        arg_array[0].primary     = &o_derE[l_de][0][0][0];                         /* [l_nCpMds, TL_N_QTS_E] */
+        arg_array[1].primary     = &l_scalar;                                      /* [1] */
         arg_array[2].primary     = &o_tIntE[0][0][0];                              /* [l_nCpMds, TL_N_QTS_E] */
         eqn_param.output.primary = &o_tIntE[0][0][0];                              /* [l_nCpMds, TL_N_QTS_E] */
         e_eqns1[l_de-1](&eqn_param);
@@ -606,7 +606,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
             to the missing support for TERNARY_BCAST flags outside equations) */
 
         /* 1.1 l_scratch3 = l_scalar * o_derE[l_de][l_qt][l_md][0] */
-        b_binary.execute(4, l_de-1, &l_scalar, &o_derE[l_de][0][0][0], &l_scratch3[0][0]);
+        b_binary.execute(4, l_de-1, &o_derE[l_de][0][0][0], &l_scalar, &l_scratch3[0][0]);
 
         /* 1.2 o_tIntE[l_qt][l_md][0] += l_scratch3 */
         b_binary.execute(5, l_de-1, &o_tIntE[0][0][0], &l_scratch3[0][0], &o_tIntE[0][0][0]);

--- a/src/impl/seismic/kernels/TimePredSingle.hpp
+++ b/src/impl/seismic/kernels/TimePredSingle.hpp
@@ -32,8 +32,13 @@
 #include "data/UnaryXsmm.hpp"
 #include "data/BinaryXsmm.hpp"
 #include "data/TernaryXsmm.hpp"
+#include "data/XsmmUtils.hpp"
 
 #define ELTWISE_TPP
+
+#ifdef ELTWISE_TPP
+#  define EQUATION_TPP
+#endif
 
 namespace edge {
   namespace seismic {
@@ -105,6 +110,12 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
     //! ternary kernels
     edge::data::TernaryXsmm< TL_T_REAL > t_ternary;
 
+#ifdef EQUATION_TPP
+    std::vector<libxsmm_matrix_eqn_function>  e_eqns00;
+    std::vector<libxsmm_matrix_eqn_function>  e_eqns01;
+    std::vector<libxsmm_matrix_eqn_function>  e_eqns1;
+#endif
+
     /**
      * Generates the matrix kernels for the transposed stiffness matrices and star matrices.
      **/
@@ -161,7 +172,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
                     static_cast<TL_T_REAL>(1.0), // beta
                     LIBXSMM_GEMM_PREFETCH_NONE );
         }
-      }
+      } /* loop over l_de for adding matrix kernels */
 
 #ifdef ELTWISE_TPP
       // initialize zero-derivative, reset time integrated dofs
@@ -191,12 +202,183 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       // update time integrated dofs
       for( unsigned short l_de = 1; l_de < TL_O_TI; l_de++ ) {
         unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
-        //std::cout << "l_de = " << l_de << " l_nCpMds = " << l_nCpMds << " TL_N_MDS = " << TL_N_MDS << std::endl;
         b_binary.add(4, l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_MDS, TL_N_MDS, TL_N_MDS /* ldi0, ldi1, ldo */,
                       LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
         b_binary.add(5, l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_MDS, TL_N_MDS, TL_N_MDS /* ldi0, ldi1, ldo */,
                       LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
       }
+#  ifdef EQUATION_TPP
+
+      for( unsigned short l_de = 1; l_de < TL_O_TI; l_de++ ) {
+        unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
+
+        // common part for all equations added below
+
+        libxsmm_datatype dtype      = XsmmDtype<TL_T_REAL>();
+        libxsmm_datatype dtype_comp = XsmmDtype<TL_T_REAL>();
+
+        libxsmm_meqn_arg_shape  eqn_out_arg_shape;
+        libxsmm_meqn_arg_shape  arg_shape;
+
+        libxsmm_matrix_arg_attributes arg_singular_attr;
+
+        libxsmm_matrix_eqn_arg_metadata arg_metadata;
+        libxsmm_matrix_eqn_op_metadata  op_metadata;
+
+        libxsmm_bitfield binary_flags;
+        libxsmm_bitfield ternary_flags;
+
+        arg_singular_attr.type = LIBXSMM_MATRIX_ARG_TYPE_SINGULAR;
+
+        // adding to eqns00 (multiply with relaxation frequency and add, part 1)
+
+        libxsmm_blasint my_eqn00 = libxsmm_matrix_eqn_create();         /* o_derA[l_de] = l_rfs[l_rm] * (l_scratch + o_derA[l-de-1]) */
+
+        binary_flags             = LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1;
+        op_metadata.eqn_idx      = my_eqn00;
+        op_metadata.op_arg_pos   = -1;
+        libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_BINARY_MUL, dtype_comp, binary_flags);
+
+        binary_flags             = LIBXSMM_MELTW_FLAG_BINARY_NONE;
+        op_metadata.eqn_idx      = my_eqn00;
+        op_metadata.op_arg_pos   = -1;
+        libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_BINARY_ADD, dtype_comp, binary_flags);
+
+        arg_metadata.eqn_idx     = my_eqn00;
+        arg_metadata.in_arg_pos  = 0;
+        arg_shape.m    = TL_N_MDS;                                      /* l_scratch, [TL_N_MDS][TL_N_QTS_M] */
+        arg_shape.n    = TL_N_QTS_M;
+        arg_shape.ld   = TL_N_MDS;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+        arg_metadata.eqn_idx     = my_eqn00;
+        arg_metadata.in_arg_pos  = 1;
+        arg_shape.m    = TL_N_MDS;                                      /* o_derA[l_de-1], [TL_N_MDS][TL_N_QTS_M] */
+        arg_shape.n    = TL_N_QTS_M;
+        arg_shape.ld   = TL_N_MDS;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+        arg_metadata.eqn_idx     = my_eqn00;
+        arg_metadata.in_arg_pos  = 2;
+        arg_shape.m    = 1;                                             /* l_rfs[l_rm], [1] */
+        arg_shape.n    = 1;
+        arg_shape.ld   = 1;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+        eqn_out_arg_shape.m    = TL_N_MDS;                             /* o_derA[l_de], [TL_N_MDS][TL_N_QTS_M] */
+        eqn_out_arg_shape.n    = TL_N_QTS_M;
+        eqn_out_arg_shape.ld   = TL_N_MDS;
+        eqn_out_arg_shape.type = dtype;
+
+        libxsmm_matrix_eqn_tree_print( my_eqn00 );
+        libxsmm_matrix_eqn_rpn_print ( my_eqn00 );
+        libxsmm_matrix_eqn_function func00 = libxsmm_dispatch_matrix_eqn_v2( my_eqn00, eqn_out_arg_shape );
+        if ( func00 == NULL) {
+          fprintf( stderr, "JIT for TPP equation func00 (eqn00) failed. Bailing...!\n");
+          exit(-1);
+        }
+        e_eqns00.push_back(func00);
+
+        // adding to eqns01 (multiply with relaxation frequency and add, part 2)
+
+
+        libxsmm_blasint my_eqn01 = libxsmm_matrix_eqn_create();         /* o_tintA += l_scalar * o_derA */
+
+        ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_0;
+        op_metadata.eqn_idx      = my_eqn01;
+        op_metadata.op_arg_pos   = -1;
+        libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, dtype_comp, ternary_flags);
+
+        arg_metadata.eqn_idx     = my_eqn01;
+        arg_metadata.in_arg_pos  = 0;
+        arg_shape.m    = 1;                                             /* l_scalar, [1] */
+        arg_shape.n    = 1;
+        arg_shape.ld   = 1;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+        arg_metadata.eqn_idx     = my_eqn01;
+        arg_metadata.in_arg_pos  = 1;
+        arg_shape.m    = TL_N_MDS;                                      /* o_derA, [TL_N_MDS][TL_N_QTS_M] */
+        arg_shape.n    = TL_N_QTS_M;
+        arg_shape.ld   = TL_N_MDS;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+        arg_metadata.eqn_idx     = my_eqn01;
+        arg_metadata.in_arg_pos  = 2;
+        arg_shape.m    = TL_N_MDS;                                      /* o_tintA, [TL_N_MDS][TL_N_QTS_M] */
+        arg_shape.n    = TL_N_QTS_M;
+        arg_shape.ld   = TL_N_MDS;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+        eqn_out_arg_shape.m    = TL_N_MDS;                             /* o_tintA, [TL_N_MDS][TL_N_QTS_M] */
+        eqn_out_arg_shape.n    = TL_N_QTS_M;
+        eqn_out_arg_shape.ld   = TL_N_MDS;
+        eqn_out_arg_shape.type = dtype;
+
+        libxsmm_matrix_eqn_tree_print( my_eqn01 );
+        libxsmm_matrix_eqn_rpn_print ( my_eqn01 );
+        libxsmm_matrix_eqn_function func01 = libxsmm_dispatch_matrix_eqn_v2( my_eqn01, eqn_out_arg_shape );
+        if ( func01 == NULL) {
+          fprintf( stderr, "JIT for TPP equation func01 (eqn01) failed. Bailing...!\n");
+          exit(-1);
+        }
+        e_eqns01.push_back(func01);
+
+        // adding to eqns1 (update time integrated DOFs)
+
+        libxsmm_blasint my_eqn1 = libxsmm_matrix_eqn_create();          /* o_tintE += l_scalar * o_derE */
+
+        ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_0;
+        op_metadata.eqn_idx      = my_eqn1;
+        op_metadata.op_arg_pos   = -1;
+        libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, dtype_comp, ternary_flags);
+
+        arg_metadata.eqn_idx     = my_eqn1;
+        arg_metadata.in_arg_pos  = 0;
+        arg_shape.m    = 1;                                             /* l_scalar, [1]*/
+        arg_shape.n    = 1;
+        arg_shape.ld   = 1;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+        arg_metadata.eqn_idx     = my_eqn1;
+        arg_metadata.in_arg_pos  = 1;
+        arg_shape.m    = l_nCpMds;                                      /* o_derE[l_de], [l_ncpMds*][TL_N_QTS_E] */
+        arg_shape.n    = TL_N_QTS_E;
+        arg_shape.ld   = TL_N_MDS;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+        arg_metadata.eqn_idx     = my_eqn1;
+        arg_metadata.in_arg_pos  = 2;
+        arg_shape.m    = l_nCpMds;                                      /* o_tIntE, [l_ncpMds*][TL_N_QTS_E] */
+        arg_shape.n    = TL_N_QTS_E;
+        arg_shape.ld   = TL_N_MDS;
+        arg_shape.type = dtype;
+        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+
+        eqn_out_arg_shape.m    = l_nCpMds;                             /* o_tIntE, [l_ncpMds*][TL_N_QTS_E] */
+        eqn_out_arg_shape.n    = TL_N_QTS_E;
+        eqn_out_arg_shape.ld   = TL_N_MDS;
+        eqn_out_arg_shape.type = dtype;
+
+        libxsmm_matrix_eqn_tree_print( my_eqn1 );
+        libxsmm_matrix_eqn_rpn_print ( my_eqn1 );
+        libxsmm_matrix_eqn_function func1 = libxsmm_dispatch_matrix_eqn_v2( my_eqn1, eqn_out_arg_shape );
+        if ( func1 == NULL) {
+          fprintf( stderr, "JIT for TPP equation func1 (eqn1) failed. Bailing...!\n");
+          exit(-1);
+        }
+        e_eqns1.push_back(func1);
+      } /* loop over l_de for TPP equations */
+#  endif
 #endif
     }
 
@@ -289,6 +471,13 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       }
 #endif
 
+#ifdef EQUATION_TPP
+      libxsmm_matrix_arg arg_array[3];
+      libxsmm_matrix_eqn_param eqn_param;
+      memset( &eqn_param, 0, sizeof(eqn_param));
+      eqn_param.inputs = arg_array;
+#endif
+
       // iterate over time derivatives
       for( unsigned short l_de = 1; l_de < TL_O_TI; l_de++ ) {
         // recursive id for the non-zero blocks
@@ -305,7 +494,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
         // buffer for the anelastic computations
         TL_T_REAL l_scratch[TL_N_QTS_M][TL_N_MDS];
-#ifdef ELTWISE_TPP
+#if defined(ELTWISE_TPP) and !defined(EQUATION_TPP)
         // buffer for relaxation computations
         TL_T_REAL l_scratch2[TL_N_QTS_M][TL_N_MDS];
         // buffer for time integrated dofs
@@ -369,9 +558,19 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
           // multiply with relaxation frequency and add
 #ifdef ELTWISE_TPP
-          /* @TODO: One could use a ternary here (but likely it is not possible right now due
-              to the missing support for TERNARY_BCAST flags outside equations) */
+#  ifdef EQUATION_TPP
+          arg_array[0].primary     = &l_scratch[0][0];               
+          arg_array[1].primary     = &o_derA[l_rm][l_de-1][0][0][0];
+          arg_array[2].primary     = const_cast<void*>(reinterpret_cast<const void*>(&l_rfs[l_rm]));
+          eqn_param.output.primary = &o_derA[l_rm][l_de][0][0][0];
+          e_eqns00[l_de-1](&eqn_param);
 
+          arg_array[0].primary     = &l_scalar;                                      /* [1] */
+          arg_array[1].primary     = &o_derA[l_rm][l_de][0][0][0];
+          arg_array[2].primary     = &o_tIntA[l_rm][0][0][0];
+          eqn_param.output.primary = &o_tIntA[l_rm][0][0][0];
+          e_eqns01[l_de-1](&eqn_param);
+#  else
           /* 1. l_scratch2[][] = l_scratch[l_qt][l_md] + o_derA[l_rm][l_de-1][l_qt][l_md][0] */
           b_binary.execute(3, 0, &l_scratch[0][0], &o_derA[l_rm][l_de-1][0][0][0], &l_scratch2[0][0]);
 
@@ -382,6 +581,8 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
           b_binary.execute(3, 2, &l_scalar, &o_derA[l_rm][l_de][0][0][0], &l_scratch2[0][0]);
           /* 3.2 o_tIntA[l_rm][l_qt][l_md][0] += l_scratch2[l_qt][l_md][0] */
           b_binary.execute(3, 3, &o_tIntA[l_rm][0][0][0], &l_scratch2[0][0], &o_tIntA[l_rm][0][0][0]);
+#  endif
+
 #else
           for( unsigned short l_qt = 0; l_qt < TL_N_QTS_M; l_qt++ ) {
 #pragma omp simd
@@ -395,6 +596,13 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
         // elastic: update time integrated DOFs
 #ifdef ELTWISE_TPP
+#  ifdef EQUATION_TPP
+        arg_array[0].primary     = &l_scalar;                                      /* [1] */
+        arg_array[1].primary     = &o_derE[l_de][0][0][0];                         /* [l_nCpMds, TL_N_QTS_E] */
+        arg_array[2].primary     = &o_tIntE[0][0][0];                              /* [l_nCpMds, TL_N_QTS_E] */
+        eqn_param.output.primary = &o_tIntE[0][0][0];                              /* [l_nCpMds, TL_N_QTS_E] */
+        e_eqns1[l_de-1](&eqn_param);
+#  else
         /* @TODO: One could use a ternary here (but likely it is not possible right now due
             to the missing support for TERNARY_BCAST flags outside equations) */
 
@@ -403,6 +611,7 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
         /* 1.2 o_tIntE[l_qt][l_md][0] += l_scratch3 */
         b_binary.execute(5, l_de-1, &o_tIntE[0][0][0], &l_scratch3[0][0], &o_tIntE[0][0][0]);
+#  endif
 #else
         unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
         for( unsigned short l_qt = 0; l_qt < TL_N_QTS_E; l_qt++ ) {

--- a/src/impl/seismic/kernels/VolIntFused.hpp
+++ b/src/impl/seismic/kernels/VolIntFused.hpp
@@ -311,7 +311,7 @@ class edge::seismic::kernels::VolIntFused: edge::seismic::kernels::VolInt< TL_T_
       /* TERNARY_BCAST is only supported in equations but not in standalone TPPs */
       t_ternary.add(0, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1);
 #  else
-      b_binary.add(1, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(1, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
       b_binary.add(1, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
 #  endif
 
@@ -491,7 +491,7 @@ class edge::seismic::kernels::VolIntFused: edge::seismic::kernels::VolInt< TL_T_
         t_ternary.execute(0, 0, &io_dofsA[l_rm][0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
 #  else
         /* 2.1 l_scratch2[l_qt][l_md][l_cr] *= l_rfs[l_rm] */
-        b_binary.execute(1, 0, &l_rfs[l_rm], &l_scratch2[0][0][0], &l_scratch2[0][0][0]);
+        b_binary.execute(1, 0, &l_scratch2[0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0]);
 
         /* 2.1 io_dofsA[l_rm][l_qt][l_md][l_cr] += l_scratch2[l_qt][l_md][l_cr] */
         b_binary.execute(1, 1, &io_dofsA[l_rm][0][0][0], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);

--- a/src/impl/seismic/kernels/VolIntSingle.hpp
+++ b/src/impl/seismic/kernels/VolIntSingle.hpp
@@ -33,8 +33,14 @@
 #include "data/UnaryXsmm.hpp"
 #include "data/BinaryXsmm.hpp"
 #include "data/TernaryXsmm.hpp"
+#include "data/XsmmUtils.hpp"
 
 #define ELTWISE_TPP
+
+#ifdef ELTWISE_TPP
+#  define EQUATION_TPP
+#endif
+
 //#define USE_TERNARY
 
 #ifdef USE_TERNARY
@@ -103,6 +109,10 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
 
     //! ternary kernels
     edge::data::TernaryXsmm< TL_T_REAL > t_ternary;
+
+#ifdef EQUATION_TPP
+    libxsmm_matrix_eqn_function e_eqn;
+#endif
 
     //! pointers to the stiffness matrices
     TL_T_REAL *m_stiff[TL_N_DIS] = {};
@@ -177,6 +187,85 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
       b_binary.add(1, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
 #  endif
 
+#  ifdef EQUATION_TPP
+      libxsmm_datatype dtype      = XsmmDtype<TL_T_REAL>();
+      libxsmm_datatype dtype_comp = XsmmDtype<TL_T_REAL>();
+
+      libxsmm_meqn_arg_shape  eqn_out_arg_shape;
+      libxsmm_meqn_arg_shape  arg_shape;
+
+      libxsmm_matrix_arg_attributes arg_singular_attr;
+
+      libxsmm_matrix_eqn_arg_metadata arg_metadata;
+      libxsmm_matrix_eqn_op_metadata  op_metadata;
+
+      libxsmm_bitfield binary_flags;
+      libxsmm_bitfield ternary_flags;
+
+      arg_singular_attr.type = LIBXSMM_MATRIX_ARG_TYPE_SINGULAR;
+
+      // adding to e_eqn (multiply with relaxation frequency and add)
+
+      libxsmm_blasint my_eqn = libxsmm_matrix_eqn_create();         /* io_dofsA[l_rm][][][0] += l_rfs[l_rm] * ( l_scratch[][][0] - i_tDofsA[l_rm][][][0] */
+
+      ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1;
+      op_metadata.eqn_idx      = my_eqn;
+      op_metadata.op_arg_pos   = -1;
+      libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, dtype_comp, ternary_flags);
+
+      binary_flags             = LIBXSMM_MELTW_FLAG_BINARY_NONE;
+      op_metadata.eqn_idx      = my_eqn;
+      op_metadata.op_arg_pos   = -1;
+      libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_BINARY_SUB, dtype_comp, binary_flags);
+
+      arg_metadata.eqn_idx     = my_eqn;
+      arg_metadata.in_arg_pos  = 0;
+      arg_shape.m    = TL_N_MDS;                                      /* l_scratch, [TL_N_MDS][TL_N_QTS_M] */
+      arg_shape.n    = TL_N_QTS_M;
+      arg_shape.ld   = TL_N_MDS;
+      arg_shape.type = dtype;
+      libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+      arg_metadata.eqn_idx     = my_eqn;
+      arg_metadata.in_arg_pos  = 1;
+      arg_shape.m    = TL_N_MDS;                                      /* i_tDofsA[l_rm], [TL_N_MDS][TL_N_QTS_M] */
+      arg_shape.n    = TL_N_QTS_M;
+      arg_shape.ld   = TL_N_MDS;
+      arg_shape.type = dtype;
+      libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+      arg_metadata.eqn_idx     = my_eqn;
+      arg_metadata.in_arg_pos  = 2;
+      arg_shape.m    = 1;                                             /* l_rfs[l_rm], [1] */
+      arg_shape.n    = 1;
+      arg_shape.ld   = 1;
+      arg_shape.type = dtype;
+      libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+      arg_metadata.eqn_idx     = my_eqn;
+      arg_metadata.in_arg_pos  = 3;
+      arg_shape.m    = TL_N_MDS;                                      /* io_DofsA[l_rm], [TL_N_MDS][TL_N_QTS_M] */
+      arg_shape.n    = TL_N_QTS_M;
+      arg_shape.ld   = TL_N_MDS;
+      arg_shape.type = dtype;
+      libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+
+      eqn_out_arg_shape.m    = TL_N_MDS;                              /* io_DofsA[l_rm], [TL_N_MDS][TL_N_QTS_M] */
+      eqn_out_arg_shape.n    = TL_N_QTS_M;
+      eqn_out_arg_shape.ld   = TL_N_MDS;
+      eqn_out_arg_shape.type = dtype;
+
+      libxsmm_matrix_eqn_tree_print( my_eqn );
+      libxsmm_matrix_eqn_rpn_print ( my_eqn );
+      e_eqn = libxsmm_dispatch_matrix_eqn_v2( my_eqn, eqn_out_arg_shape );
+      if ( e_eqn == NULL) {
+        fprintf( stderr, "JIT for TPP equation e_eqn (my_eqn) failed. Bailing...!\n");
+        exit(-1);
+      }
+#  endif
+
+
 #endif
     }
 
@@ -226,7 +315,7 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
 
       // buffer for anelastic part
       TL_T_REAL l_scratch[TL_N_QTS_M][TL_N_MDS][1];
-#ifdef ELTWISE_TPP
+#if defined(ELTWISE_TPP) and !defined(EQUATION_TPP)
       // buffer for relaxation computations
       TL_T_REAL l_scratch2[TL_N_QTS_M][TL_N_MDS][1];
 #endif
@@ -271,6 +360,13 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
         }
       }
 
+#if defined(ELTWISE_TPP) and defined(EQUATION_TPP)
+      libxsmm_matrix_arg arg_array[4];
+      libxsmm_matrix_eqn_param eqn_param;
+      memset( &eqn_param, 0, sizeof(eqn_param));
+      eqn_param.inputs = arg_array;
+#endif
+
       for( unsigned short l_rm = 0; l_rm < TL_N_RMS; l_rm++ ) {
         // add contribution of source matrix
         m_mm.execute( 1, 1,
@@ -283,19 +379,28 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
 
         // multiply with relaxation frequency and add
 #ifdef ELTWISE_TPP
+#  ifdef EQUATION_TPP
+        arg_array[0].primary     = &l_scratch[0][0][0];
+        arg_array[1].primary     = const_cast<void*>(reinterpret_cast<const void*>(&i_tDofsA[l_rm][0][0]));
+        arg_array[2].primary     = const_cast<void*>(reinterpret_cast<const void*>(&l_rfs[l_rm]));
+        arg_array[3].primary     = &io_dofsA[l_rm][0][0][0];
+        eqn_param.output.primary = &io_dofsA[l_rm][0][0][0];
+        e_eqn(&eqn_param);
+#  else
         // @TODO: Could be replaced by a single equation (provided no data races occur)
         /* 1. l_scratch2[][] = l_scratch[l_qt][l_md][0] - i_tDofsA[l_rm][l_qt][l_md][0] */
         b_binary.execute(0, 0, &l_scratch[0][0][0], &i_tDofsA[l_rm][0][0][0], &l_scratch2[0][0][0]);
 
-#  ifdef USE_TERNARY
+#    ifdef USE_TERNARY
         /* This does not work, see comments in generateKernels() */
         /* 2. io_dofsA[l_rm][l_qt][l_md][0] += l_rfs[l_rm] * l_scratch2[l_qt][l_md][0] */
         t_ternary.execute(0, 0, &io_dofsA[l_rm][0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
-#  else
+#   else
         /* 2.1 l_scratch2[l_qt][l_md][0] *= l_rfs[l_rm] */
         b_binary.execute(1, 0, &l_rfs[l_rm], &l_scratch2[0][0][0], &l_scratch2[0][0][0]);
         /* 2.1 io_dofsA[l_rm][l_qt][l_md][0] += l_scratch2[l_qt][l_md][0] */
         b_binary.execute(1, 1, &io_dofsA[l_rm][0][0][0], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
+#    endif
 #  endif
 
 #else

--- a/src/impl/seismic/kernels/VolIntSingle.hpp
+++ b/src/impl/seismic/kernels/VolIntSingle.hpp
@@ -183,7 +183,7 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
       /* TERNARY_BCAST is only supported in equations but not in standalone TPPs */
       t_ternary.add(0, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1);
 #  else
-      b_binary.add(1, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_0);
+      b_binary.add(1, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
       b_binary.add(1, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
 #  endif
 
@@ -256,8 +256,8 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
       eqn_out_arg_shape.ld   = TL_N_MDS;
       eqn_out_arg_shape.type = dtype;
 
-      libxsmm_matrix_eqn_tree_print( my_eqn );
-      libxsmm_matrix_eqn_rpn_print ( my_eqn );
+      //libxsmm_matrix_eqn_tree_print( my_eqn );
+      //libxsmm_matrix_eqn_rpn_print ( my_eqn );
       e_eqn = libxsmm_dispatch_matrix_eqn_v2( my_eqn, eqn_out_arg_shape );
       if ( e_eqn == NULL) {
         fprintf( stderr, "JIT for TPP equation e_eqn (my_eqn) failed. Bailing...!\n");
@@ -397,7 +397,7 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
         t_ternary.execute(0, 0, &io_dofsA[l_rm][0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
 #   else
         /* 2.1 l_scratch2[l_qt][l_md][0] *= l_rfs[l_rm] */
-        b_binary.execute(1, 0, &l_rfs[l_rm], &l_scratch2[0][0][0], &l_scratch2[0][0][0]);
+        b_binary.execute(1, 0, &l_scratch2[0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0]);
         /* 2.1 io_dofsA[l_rm][l_qt][l_md][0] += l_scratch2[l_qt][l_md][0] */
         b_binary.execute(1, 1, &io_dofsA[l_rm][0][0][0], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
 #    endif


### PR DESCRIPTION
- Added under (currently enabled) macro EQUATIONS_TPP which should be combined with active ELTWISE_TPP (also enabled),  in TimePredSingle.hpp and VolIntSingle.hpp.
- Moved BCAST from the first argument to second (for ternary) and second (for binary) in order to improve perf potentially. Both in Single and Fused kernels which used BCAST.
- Removed extra prints for equations created

Tested functional correctness with specified single/fused tests.